### PR TITLE
Fix RNAudioPlayer require

### DIFF
--- a/AudioPlayer.js
+++ b/AudioPlayer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var RNAudioPlayer = require('NativeModules').RNAudioPlayer;
+var RNAudioPlayer = require('react-native').NativeModules.RNAudioPlayer;
 
 var AudioPlayer = {
   play(fileName: string) {


### PR DESCRIPTION
Per http://facebook.github.io/react-native/docs/native-modules-ios.html, it looks like the `require` should be:

`require('react-native').NativeModules.RNAudioPlayer`

Instead of:

`require('NativeModules').RNAudioPlayer`