### PR TITLE
Add pause stop and finished event notification

### DIFF
--- a/AudioPlayer.js
+++ b/AudioPlayer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var RNAudioPlayer = require('NativeModules').RNAudioPlayer;
+var RNAudioPlayer = require('react-native').NativeModules.RNAudioPlayer;
 
 var AudioPlayer = {
   play(fileName: string) {

--- a/AudioPlayer.js
+++ b/AudioPlayer.js
@@ -1,11 +1,27 @@
 'use strict';
 
 var RNAudioPlayer = require('react-native').NativeModules.RNAudioPlayer;
+var NativeAppEventEmitter = require('react-native').NativeAppEventEmitter;
 
-var AudioPlayer = {
+module.exports = class AudioPlayer {
+  constructor(options) {
+    if (options && options.onPlaybackFinished) {
+      NativeAppEventEmitter.addListener(
+        'AudioPlayerDidFinishPlaying',
+        options.onPlaybackFinished
+      );
+    }
+  }
+
   play(fileName: string) {
     RNAudioPlayer.play(fileName);
   }
-};
 
-module.exports = AudioPlayer;
+  pause() {
+    RNAudioPlayer.pause();
+  }
+
+  stop() {
+    RNAudioPlayer.stop();
+  }
+};

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install react-native-audioplayer --save
 
 In XCode, in the project navigator, right click Libraries ➜ Add Files to [your project's name] Go to node_modules ➜ react-native-audioplayer and add the .xcodeproj file
 
-In XCode, in the project navigator, select your project. Add the lib*.a from the audioplayer project to your project's Build Phases ➜ Link Binary With Libraries Click .xcodeproj file you added before in the project navigator and go the Build Settings tab. Make sure 'All' is toggled on (instead of 'Basic'). Look for Header Search Paths and make sure it contains both $(SRCROOT)/../react-native/React and $(SRCROOT)/../../React - mark both as recursive.
+In XCode, in the project navigator, select your project. Add the lib*.a from the audioplayer project to your project's Build Phases ➜ Link Binary With Libraries. Click .xcodeproj file you added before in the project navigator and go the Build Settings tab. Make sure 'All' is toggled on (instead of 'Basic'). Look for Header Search Paths and make sure it contains both $(SRCROOT)/../react-native/React and $(SRCROOT)/../../React - mark both as recursive.
 
 Run your project (Cmd+R)
 
@@ -26,10 +26,17 @@ The AudioPlayer API is exposed at AudioPlayer.play(soundName). The sound is play
 
 ```javascript
 
-//require module
+// require module
 var AudioPlayer = require('react-native-audioplayer');
 
-//play sound
-AudioPlayer.play('beep.mp3');
+// create instance of player with callback for playback finished event
+var audioPlayer = new AudioPlayer({
+  onFinishedPlayback: function() {
+    console.log('playback finished!');
+  }
+});
+
+// play sound
+audioPlayer.play('beep.mp3');
 
 ```

--- a/RNAudioPlayer.h
+++ b/RNAudioPlayer.h
@@ -1,4 +1,5 @@
 #import "RCTBridgeModule.h"
+#import "RCTEventDispatcher.h"
 #import <AVFoundation/AVFoundation.h>
 
 @interface RNAudioPlayer : NSObject <RCTBridgeModule>

--- a/RNAudioPlayer.m
+++ b/RNAudioPlayer.m
@@ -1,21 +1,53 @@
 #import "RNAudioPlayer.h"
+#import "RCTBridge.h"
+#import "RCTEventDispatcher.h"
 
 @implementation RNAudioPlayer
 
 RCT_EXPORT_MODULE()
 
+@synthesize bridge = _bridge;
+
+- (instancetype)init
+{
+    self = [super init];
+    
+    if (self) {
+        AVAudioSession *session = [AVAudioSession sharedInstance];
+        [session setCategory: AVAudioSessionCategoryPlayback error: nil];
+        [session setActive: YES error: nil];
+    }
+    
+    return self;
+}
+
 RCT_EXPORT_METHOD(play:(NSString *)fileName)
 {
-    AVAudioSession *session = [AVAudioSession sharedInstance];
-    [session setCategory: AVAudioSessionCategoryPlayback error: nil];
-    [session setActive: YES error: nil];
-    
-    NSURL *soundURL = [[NSBundle mainBundle] URLForResource:[[fileName lastPathComponent] stringByDeletingPathExtension]
+    if (fileName) {
+        NSURL *soundURL = [[NSBundle mainBundle] URLForResource:[[fileName lastPathComponent] stringByDeletingPathExtension]
                                              withExtension:[fileName pathExtension]];
     
-    self.audioPlayer = [[AVAudioPlayer alloc] initWithContentsOfURL:soundURL error:nil];
+        self.audioPlayer = [[AVAudioPlayer alloc] initWithContentsOfURL:soundURL error:nil];
+        self.audioPlayer.delegate = self;
+    }
     
     [self.audioPlayer play];
+}
+
+
+RCT_EXPORT_METHOD(pause)
+{
+    [self.audioPlayer pause];
+}
+
+RCT_EXPORT_METHOD(stop)
+{
+    [self.audioPlayer stop];
+}
+
+
+- (void)audioPlayerDidFinishPlaying:(AVAudioPlayer *)player successfully:(BOOL)flag {
+    [self.bridge.eventDispatcher sendAppEventWithName:@"AudioPlayerDidFinishPlaying" body:nil];
 }
 
 @end


### PR DESCRIPTION
This PR adds support for:
- pause
- stop
- unpause (just call `play` without a filename)
- event notification when playback has finished

For the event notification, it made sense to register the callback when creating the player which means it made sense to have the player be a class we create an instance of. It doesn't have to be that way but it seemed straight forward. So I did that.
