### PR TITLE
FIx path to native modules

### DIFF
--- a/AudioPlayer.js
+++ b/AudioPlayer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var RNAudioPlayer = require('NativeModules').RNAudioPlayer;
+var RNAudioPlayer = require('react-native').NativeModules.RNAudioPlayer;
 
 var AudioPlayer = {
   play(fileName: string) {


### PR DESCRIPTION
React-Native packager error `Unable to resolve module NativeModules from .../node_modules/react-native-audioplayer/AudioPlayer.js`
This seems to fix it.