### PR TITLE
added support for streaming .mp3 from we URL on iOS

### DIFF
--- a/AudioPlayer.js
+++ b/AudioPlayer.js
@@ -7,7 +7,7 @@ var AudioPlayer = {
   play(fileName: string) {
     fileName = Platform.OS === 'ios' ? fileName : fileName.replace(/\.[^/.]+$/, "");
     RNAudioPlayer.play(fileName);
-  }
+  },
   
   playFromURL(fileName: string) {
     RNAudioPlayer.playFromURL(fileName);

--- a/AudioPlayer.js
+++ b/AudioPlayer.js
@@ -8,6 +8,10 @@ var AudioPlayer = {
     fileName = Platform.OS === 'ios' ? fileName : fileName.replace(/\.[^/.]+$/, "");
     RNAudioPlayer.play(fileName);
   }
+  
+  playFromURL(fileName: string) {
+    RNAudioPlayer.playFromURL(fileName);
+  }
 };
 
 module.exports = AudioPlayer;

--- a/RNAudioPlayer.h
+++ b/RNAudioPlayer.h
@@ -4,5 +4,6 @@
 @interface RNAudioPlayer : NSObject <RCTBridgeModule>
 
 @property (strong, nonatomic) AVAudioPlayer *audioPlayer;
+@property (strong, nonatomic) AVPlayer *audioPlayerURL;
 
 @end

--- a/RNAudioPlayer.m
+++ b/RNAudioPlayer.m
@@ -18,4 +18,13 @@ RCT_EXPORT_METHOD(play:(NSString *)fileName)
     [self.audioPlayer play];
 }
 
+RCT_EXPORT_METHOD(playFromURL:(NSString *)url)
+{
+    NSURL *soundURL=[NSURL URLWithString:url];
+	AVPlayerItem *playerItem = [AVPlayerItem playerItemWithURL: soundURL];
+	self.audioPlayerURL = [AVPlayer playerWithPlayerItem:playerItem];
+	[self.audioPlayerURL play];
+	self.audioPlayerURL.actionAtItemEnd = AVPlayerActionAtItemEndNone;
+}
+
 @end

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:andreaskeller/react-native-audioplayer.git"
+    "url": "https://github.com/tbinetruy/react-native-audioplayer"
   },
   "keywords": [
     "react-component",
@@ -17,6 +17,6 @@
     "android",
     "audioplayer"
   ],
-  "author": "Andreas Keller <andreas.keller@gmx.ch> (https://github.com/andreaskeller)",
+  "author": "Thomas Binetruy and Andreas Keller (forked from https://github.com/andreaskeller/react-native-audioplayer)",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-audioplayer",
+  "name": "react-native-stream-audio-from-url",
   "version": "0.2.0",
   "description": "Small audio player library for react native",
   "main": "AudioPlayer.js",


### PR DESCRIPTION
On iOS, we can now pass a web URL to AudioPlayer like this:

`
AudioPlayer.playFromURL("http://www.jplayer.org/audio/mp3/Miaow-07-Bubble.mp3")
`

or

`
AudioPlayer.playFromURL("https://api.soundcloud.com/tracks/151854794/stream?client_id=" + SC_CLIENT_ID)
`
